### PR TITLE
Fix for preventing incorrect -lFALSE option while linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ add_definitions(-DCONFIG_DIR="${CONFIG_DIR}")
 set(BLA_VENDOR "OpenBLAS")
 find_package( BLAS )
 
+if ( BLAS_LIBRARIES STREQUAL "FALSE")
+	unset(BLAS_LIBRARIES)
+endif()
+
 if ( ${BLAS_FOUND} )
     MESSAGE("BLAS information:")
     MESSAGE("  BLAS Vendor: ${BLA_VENDOR}")

--- a/lib/3rdParty/dlib/CMakeLists.txt
+++ b/lib/3rdParty/dlib/CMakeLists.txt
@@ -427,6 +427,10 @@ if (NOT TARGET dlib)
    else()
       remove_global_define(ENABLE_ASSERTS)
    endif()
-
+   
+# According to https://cmake.org/Bug/view.php?id=14444  install(TARGETS)
+# command flow accepts only targets created within same directory.
+         
+  install (TARGETS dlib EXPORT OpenFaceTargets LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 
 endif()


### PR DESCRIPTION
Checking if BLAS_LIBRARIES variable  has FALSE value